### PR TITLE
Insert allows using non-default schema

### DIFF
--- a/src/Npgsql.Bulk/Model/InsertQueryParts.cs
+++ b/src/Npgsql.Bulk/Model/InsertQueryParts.cs
@@ -11,6 +11,8 @@ namespace Npgsql.Bulk.Model
 
         public string TableName { get; set; }
 
+        public string TableNameQualified { get; set; }
+
         public string TargetColumnNamesQueryPart { get; set; }
 
         public string SourceColumnNamesQueryPart { get; set; }

--- a/src/Npgsql.Bulk/Model/MappingInfo.cs
+++ b/src/Npgsql.Bulk/Model/MappingInfo.cs
@@ -11,6 +11,8 @@ namespace Npgsql.Bulk.Model
 
         public string TableName { get; set; }
 
+        public string TableNameQualified { get; set; }
+
         public string TempAliasedColumnName { get; internal set; }
 
         public string QualifiedColumnName { get; internal set; }

--- a/src/Npgsql.Bulk/NpgsqlBulkUploader.cs
+++ b/src/Npgsql.Bulk/NpgsqlBulkUploader.cs
@@ -161,7 +161,7 @@ namespace Npgsql.Bulk
                 {
                     using (var cmd = conn.CreateCommand())
                     {
-                        var baseInsertCmd = $"INSERT INTO {insertPart.TableName} ({insertPart.TargetColumnNamesQueryPart}) SELECT {insertPart.SourceColumnNamesQueryPart} FROM {tempTableName}";
+                        var baseInsertCmd = $"INSERT INTO {insertPart.TableNameQualified} ({insertPart.TargetColumnNamesQueryPart}) SELECT {insertPart.SourceColumnNamesQueryPart} FROM {tempTableName}";
                         if (string.IsNullOrEmpty(insertPart.ReturningSetQueryPart))
                         {
                             cmd.CommandText = baseInsertCmd;
@@ -351,6 +351,7 @@ namespace Npgsql.Bulk
                 .Select(x => new
                 {
                     TableName = x.Key,
+                    x.First().TableNameQualified,
                     KeyInfos = x.Where(y => y.IsKey).ToList(),
                     ClientDataInfos = x.Where(y => !y.IsDbGenerated).ToList(),
                     ReturningInfos = x.Where(y => y.IsDbGenerated).ToList()
@@ -371,7 +372,8 @@ namespace Npgsql.Bulk
                 return new InsertQueryParts()
                 {
                     TableName = x.TableName,
-                    TargetColumnNamesQueryPart = string.Join(", ", x.ClientDataInfos.Select(y => y.ColumnInfo.ColumnName)),
+                    TableNameQualified = x.TableNameQualified,
+                    TargetColumnNamesQueryPart = string.Join(", ", x.ClientDataInfos.Select(y => NpgsqlHelper.GetQualifiedName(y.ColumnInfo.ColumnName))),
                     SourceColumnNamesQueryPart = string.Join(", ", x.ClientDataInfos.Select(y => y.TempAliasedColumnName)),
                     Returning = string.Join(", ", x.ReturningInfos.Select(y => y.ColumnInfo.ColumnName)),
                     ReturningSetQueryPart = string.Join(", ", others.Select(y => $"{y.My.TempAliasedColumnName} = source.{y.Others.ColumnInfo.ColumnName}"))
@@ -381,7 +383,7 @@ namespace Npgsql.Bulk
             info.SelectSourceForInsertQuery = "SELECT " +
                 string.Join(", ", info.ClientDataInfos
                     .Select(x => $"{x.QualifiedColumnName} AS {x.TempAliasedColumnName}")) +
-                " FROM " + string.Join(", ", grouppedByTables.Select(x => x.TableName));
+                " FROM " + string.Join(", ", grouppedByTables.Select(x => x.TableNameQualified));
             info.CopyColumnsForInsertQueryPart = string.Join(", ", info.ClientDataInfos
                 .Select(x => x.TempAliasedColumnName));
 

--- a/src/Npgsql.Bulk/NpgsqlHelper.cs
+++ b/src/Npgsql.Bulk/NpgsqlHelper.cs
@@ -79,6 +79,7 @@ namespace Npgsql.Bulk
                         return new MappingInfo()
                         {
                             TableName = tableName,
+                            TableNameQualified = GetQualifiedName(tableName, tableEntitySet.Schema),
                             Property = type.GetProperty(x.Property.Name,
                                 BindingFlags.NonPublic | BindingFlags.Public |
                                 BindingFlags.GetProperty | BindingFlags.Instance),


### PR DESCRIPTION
Hello, thanks for creating this project. I've just ported some existing  code which uses non-default ("public") schemas to use your library. I got a few exceptions from the generated SQL queries when using the Insert method. They relate to not using fully qualified table & column names. I've updated just enough code to get the Insert method working for my use case. I tried to follow your existing conventions as best as possible. I have no experience dealing with EF6 model metadata so my changes are potentially non-optimal or may not work in other environments. 

The temp tables that the library creates will still use the default schema - this is because the fully qualified table names from the model are derived on a per-entity set basis. We may want to find a way to inspect the `modelBuilder.HasDefaultSchema` value that is set in `DbContext.OnModelCreating` to be used for the temp tables as a convention.. Alternatively perhaps a high level property that can be set as an override.

I did not test the Update method.