### PR TITLE
Fix smallint

### DIFF
--- a/src/Npgsql.Bulk/NpgsqlBulkUploader.cs
+++ b/src/Npgsql.Bulk/NpgsqlBulkUploader.cs
@@ -66,6 +66,7 @@ namespace Npgsql.Bulk
                     return NpgsqlDbType.Time;
                 case "date":
                     return NpgsqlDbType.Date;
+                case "int2":
                 case "smallint":
                     return NpgsqlDbType.Smallint;
                 case "uuid":


### PR DESCRIPTION
Postgres can return "int2" instead of "smallint" for smallint type. Here is the fix