### PR TITLE
changed where clause concatenation

### DIFF
--- a/src/Npgsql.Bulk/NpgsqlBulkUploader.cs
+++ b/src/Npgsql.Bulk/NpgsqlBulkUploader.cs
@@ -421,7 +421,7 @@ namespace Npgsql.Bulk
                         var colName = NpgsqlHelper.GetQualifiedName(y.ColumnInfo.ColumnName);
                         return $"{colName} = source.{y.TempAliasedColumnName}";
                     })),
-                    WhereClause = string.Join(", ", x.KeyInfos.Select(y =>
+                    WhereClause = string.Join(" and ", x.KeyInfos.Select(y =>
                     {
                         var colName = NpgsqlHelper.GetQualifiedName(y.ColumnInfo.ColumnName);
                         return $"{colName} = source.{y.TempAliasedColumnName}";


### PR DESCRIPTION
Changed the string that concatenates the WhereClause for the UpdateQueryParts obj. This was done to be able to update objects with more than one key.