### PR TITLE
Using name as key instead of PropertyInfo

### DIFF
--- a/src/Npgsql.Bulk/InsertConflictAction.cs
+++ b/src/Npgsql.Bulk/InsertConflictAction.cs
@@ -107,7 +107,7 @@ namespace Npgsql.Bulk
 
                 if (conflictProperty != null)
                 {
-                    if (!mapping.PropToMappingInfo.TryGetValue(conflictProperty, out MappingInfo info))
+                    if (!mapping.PropToMappingInfo.TryGetValue(conflictProperty.Name, out MappingInfo info))
                         throw new InvalidOperationException($"Can't find property {conflictProperty} in mapping");
 
                     conflictTarget = $"({NpgsqlHelper.GetQualifiedName(info.ColumnInfo.ColumnName)})";
@@ -117,7 +117,7 @@ namespace Npgsql.Bulk
                 sb.Append("DO UPDATE SET ");
                 foreach (var updateProp in updateProperties)
                 {
-                    if (!mapping.PropToMappingInfo.TryGetValue(updateProp, out MappingInfo info))
+                    if (!mapping.PropToMappingInfo.TryGetValue(updateProp.Name, out MappingInfo info))
                         throw new InvalidOperationException($"Can't find property {updateProp} in mapping");
 
                     sb.Append(NpgsqlHelper.GetQualifiedName(info.ColumnInfo.ColumnName));

--- a/src/Npgsql.Bulk/Model/EntityInfo.cs
+++ b/src/Npgsql.Bulk/Model/EntityInfo.cs
@@ -16,7 +16,7 @@ namespace Npgsql.Bulk.Model
 
         public List<MappingInfo> MappingInfos { get; set; }
 
-        public Dictionary<PropertyInfo, MappingInfo> PropToMappingInfo { get; set; }
+        public Dictionary<string, MappingInfo> PropToMappingInfo { get; set; }
 
         public string SelectSourceForInsertQuery { get; set; }
 

--- a/src/Npgsql.Bulk/NpgsqlBulkUploader.cs
+++ b/src/Npgsql.Bulk/NpgsqlBulkUploader.cs
@@ -774,7 +774,7 @@ namespace Npgsql.Bulk
                 TableName = tableName,
                 CodeBuilder = codeBuilder,
                 MappingInfos = mappingInfo,
-                PropToMappingInfo = mappingInfo.ToDictionary(x => x.Property),
+                PropToMappingInfo = mappingInfo.ToDictionary(x => x.Property.Name),
                 TableNames = mappingInfo.Select(x => x.TableName).Distinct().ToArray(),
                 ClientDataInfos = mappingInfo.Where(x => !x.IsDbGenerated).ToArray(),
                 ClientDataWithKeysInfos = mappingInfo.Where(x => !x.IsDbGenerated || x.IsKey).ToArray()


### PR DESCRIPTION
There is a bug/limitation where if an expression is created from a base type/interface, InsertConflictAction fails to resolve the corresponding MappingInfo object. Using the property name as the key of the PropToMappingInfo dictionary seems to fix the issue.

In my particular use case, our entities share a set of common interfaces so we can perform operations on them generically. Without this fix, the Insert operation fails.

```
interface IEntity 
{
   int Id { get; set; }
}

class MyEntity : IHasId 
{
   int Id { get; set; }
}

class MyContext 
{
   public void BulkInsert<T>(IEnumerable<T> entities) where T : class, IEntity
   {
            var properties = this.Model
                .FindEntityType(typeof(T))
                .GetProperties()
                .Select(o => o.PropertyInfo)
                .ToArray();

            var uploader = new NpgsqlBulkUploader(context);
           
            // This fails since o => o.Id resolves to a PropertyInfo with IEntity as the type, which fails the dictionary lookup
            uploader.Insert(entities, InsertConflictAction.UpdateProperty(o => o.Id, properties));
   }
}
```