### PR TITLE
Issue/43 clear schema cache

### DIFF
--- a/src/Npgsql.Bulk/NpgsqlBulkUploader.cs
+++ b/src/Npgsql.Bulk/NpgsqlBulkUploader.cs
@@ -44,12 +44,17 @@ namespace Npgsql.Bulk
         /// </summary>
         public TableLockLevel LockLevelOnUpdate { get; set; } = TableLockLevel.ShareRowExclusive;
 
-        public NpgsqlBulkUploader(DbContext context)
-        {
-            this.context = context;
-        }
+		public NpgsqlBulkUploader(DbContext context, bool clearCache = false)
+		{
+			this.context = context;
 
-        internal static NpgsqlDbType GetNpgsqlType(ColumnInfo info)
+			if (clearCache)
+			{
+				Cache.Clear();
+			}
+		}
+
+		internal static NpgsqlDbType GetNpgsqlType(ColumnInfo info)
         {
             switch (info.ColumnType)
             {

--- a/src/Npgsql.Bulk/NpgsqlBulkUploader.cs
+++ b/src/Npgsql.Bulk/NpgsqlBulkUploader.cs
@@ -44,17 +44,17 @@ namespace Npgsql.Bulk
         /// </summary>
         public TableLockLevel LockLevelOnUpdate { get; set; } = TableLockLevel.ShareRowExclusive;
 
-		public NpgsqlBulkUploader(DbContext context, bool clearCache = false)
-		{
-			this.context = context;
-
-			if (clearCache)
-			{
-				Cache.Clear();
-			}
-		}
-
-		internal static NpgsqlDbType GetNpgsqlType(ColumnInfo info)
+        public NpgsqlBulkUploader(DbContext context, bool clearCache = false)
+        {
+            this.context = context;
+            
+            if (clearCache)
+            {
+                Cache.Clear();
+            }
+        }
+        
+        internal static NpgsqlDbType GetNpgsqlType(ColumnInfo info)
         {
             switch (info.ColumnType)
             {


### PR DESCRIPTION
As per the raised issue #43 there is a use case where we want to target different schemas, currently the first schema is cached.

This PR contains a simple change to pass a boolean parameter in the NpgsqlBulkUploader constructor to clear the schema cache.