### PR TITLE
Shorten aliased Column Names

### DIFF
--- a/src/Npgsql.Bulk/NpgsqlBulkUploader.cs
+++ b/src/Npgsql.Bulk/NpgsqlBulkUploader.cs
@@ -1016,7 +1016,7 @@ namespace Npgsql.Bulk
                 x.ModifierAttributes = modifiers?.ToList() ?? new List<BulkOperationModifierAttribute>();
                 x.OverrideSourceMethod = GetOverrideSouceFunc(type, sourceAttribute?.PropertyName);
                 x.NpgsqlType = GetNpgsqlType(x.ColumnInfo);
-                x.TempAliasedColumnName = $"{x.TableName}_{x.ColumnInfo.ColumnName}".ToLower();
+                x.TempAliasedColumnName = Guid.NewGuid().ToString().Replace("-", "_");
                 x.QualifiedColumnName = $"{NpgsqlHelper.GetQualifiedName(x.TableName)}.{NpgsqlHelper.GetQualifiedName(x.ColumnInfo.ColumnName)}";
             });
             return mappings;


### PR DESCRIPTION
Addressing #82 by removing reliance on table and column name when creating temp column name. Postgres has a 63 byte limit on column names